### PR TITLE
Use `build.commands` and open a PR to show the flyout

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,14 +7,5 @@ build:
   commands:
     # Run all the commands manually to avoid installing pre-defined packages
     # Make explicit what are the dependencies we are installing
-    - pip install sphinx sphinx-autorun
-
-    # Install "sphinx-rtd-theme" from this branch because it injects the Flyout using the new documented way.
-    # - pip install 'sphinx-rtd-theme @ git+https://github.com/readthedocs/sphinx_rtd_theme@humitos/flyout-menu'
-    - pip install sphinx-rtd-theme
-
-    - sphinx-build -b html docs/ _readthedocs/html
-
-    # Copy data from the builder
-    # This will exposed via `/_/readthedocs-config/` API endpoint
-    - cp docs/readthedocs-build.yaml _readthedocs/html/
+    - pip install sphinx sphinx-autorun sphinx-rtd-theme
+    - sphinx-build -b html docs/ $READTHEDOCS_OUTPUT/html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,14 +1,8 @@
-manual-integrations
-===================
+Documentation from a PR for testing
+===================================
 
-Initial PoC to manually integrate all the Read the Docs features.
-Context:
-
-* https://github.com/readthedocs/readthedocs.org/pull/9755
-* https://github.com/readthedocs/readthedocs.org/issues/9063
-* https://github.com/readthedocs/meta/issues/71
-* https://github.com/readthedocs/readthedocs.org/pull/10127
-* https://github.com/humitos/readthedocs-client
+It seems that for some reason the new addons are not being shown on PR:
+https://github.com/readthedocs/readthedocs.org/issues/10706
 
 ----
 


### PR DESCRIPTION
*Do not merge this PR*, it's just an example for https://github.com/readthedocs/readthedocs.org/issues/10706#issuecomment-1706465585

* 🎋 PR built at: https://beta.readthedocs.org/projects/test-builds/builds/21825281/
* 📚 Documentation render at: https://test-builds--2110.org.readthedocs.build/en/2110/